### PR TITLE
Fix schedule path

### DIFF
--- a/resources/artisan_schedule.rb
+++ b/resources/artisan_schedule.rb
@@ -26,9 +26,10 @@ action :create do
     	day '*'
     	month '*'
     	weekday '*'
-    	command "php #{new_resource.path}/artisan #{new_resource.command}"
+    	command "php artisan #{new_resource.command}"
     	user new_resource.user
     	action :create
+    	home "#{new_resource.path}"
     end
 
 end

--- a/resources/artisan_schedule.rb
+++ b/resources/artisan_schedule.rb
@@ -26,10 +26,9 @@ action :create do
     	day '*'
     	month '*'
     	weekday '*'
-    	command "php artisan #{new_resource.command}"
+    	command "cd #{new_resource.path} && php artisan #{new_resource.command}"
     	user new_resource.user
     	action :create
-    	home "#{new_resource.path}"
     end
 
 end


### PR DESCRIPTION
When schedule run come command he not found where artisan locate.
To fix it we go to project path and then run schedule. And now it more agree with doc
https://laravel.com/docs/5.8/scheduling

`* * * * * cd /path-to-your-project && php artisan schedule:run >> /dev/null 2>&1`